### PR TITLE
Add llm-mistral plugin

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -1,8 +1,8 @@
 { config, pkgs, ... }:
 let
-    sse-starlette = pkgs.callPackage ./packages/sse-starlette/default.nix { };
-    httpx-sse = pkgs.callPackage ./packages/httpx-sse/default.nix { inherit sse-starlette; };
-    llm-mistral = pkgs.callPackage ./packages/llm-mistral/default.nix { inherit httpx-sse; };
+  sse-starlette = pkgs.callPackage ./packages/sse-starlette/default.nix { };
+  httpx-sse = pkgs.callPackage ./packages/httpx-sse/default.nix { inherit sse-starlette; };
+  llm-mistral = pkgs.callPackage ./packages/llm-mistral/default.nix { inherit httpx-sse; };
   fonts = with pkgs; [
     # # It is sometimes useful to fine-tune packages, for example, by applying
     # # overrides. You can do that directly here, just don't forget the

--- a/home.nix
+++ b/home.nix
@@ -1,5 +1,8 @@
 { config, pkgs, ... }:
 let
+    sse-starlette = pkgs.callPackage ./packages/sse-starlette/default.nix { };
+    httpx-sse = pkgs.callPackage ./packages/httpx-sse/default.nix { inherit sse-starlette; };
+    llm-mistral = pkgs.callPackage ./packages/llm-mistral/default.nix { inherit httpx-sse; };
   fonts = with pkgs; [
     # # It is sometimes useful to fine-tune packages, for example, by applying
     # # overrides. You can do that directly here, just don't forget the
@@ -22,6 +25,7 @@ let
     glow
     goku
     jq
+    (llm.withPlugins [ llm-mistral ])
     neofetch
     nix-init
     nixpkgs-fmt

--- a/packages/httpx-sse/default.nix
+++ b/packages/httpx-sse/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, python3
+, fetchFromGitHub
+, sse-starlette
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "httpx-sse";
+  version = "0.4.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "florimondmanca";
+    repo = "httpx-sse";
+    rev = version;
+    hash = "sha256-nU8vkmV/WynzQrSrq9+FQXtfAJPVLpMsRSuntU0HWrE=";
+  };
+
+  nativeBuildInputs = with python3.pkgs; [
+    setuptools
+    setuptools-scm
+    wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.httpx
+    python3.pkgs.twine
+    sse-starlette
+  ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    test = [
+      black
+      mypy
+      pytest
+      pytest-asyncio
+      pytest-cov
+      ruff
+    ];
+  };
+
+  pythonImportsCheck = [ "httpx_sse" ];
+
+  meta = with lib; {
+    description = "Consume Server-Sent Event (SSE) messages with HTTPX";
+    homepage = "https://github.com/florimondmanca/httpx-sse";
+    changelog = "https://github.com/florimondmanca/httpx-sse/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.mit;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/packages/llm-claude/default.nix
+++ b/packages/llm-claude/default.nix
@@ -1,0 +1,42 @@
+{ lib
+, python3
+, fetchFromGitHub
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "llm-claude";
+  version = "0.4.0";
+  pyproject = true;
+  dontCheckRuntimeDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "tomviner";
+    repo = "llm-claude";
+    rev = version;
+    hash = "sha256-lC0Tx7zeM8gZ3Ln8VWkq29BsKsMnxHB3s+R086B5BEs=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    anthropic
+  ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    test = [
+      click
+      pytest
+    ];
+  };
+
+  meta = with lib; {
+    description = "Plugin for LLM adding support for Anthropic's Claude models";
+    homepage = "https://github.com/tomviner/llm-claude";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+    mainProgram = "llm-claude";
+  };
+}

--- a/packages/llm-mistral/default.nix
+++ b/packages/llm-mistral/default.nix
@@ -1,0 +1,43 @@
+{ lib
+, python3
+, fetchFromGitHub
+, httpx-sse
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "llm-mistral";
+  version = "0.3";
+  pyproject = true;
+  dontCheckRuntimeDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "simonw";
+    repo = "llm-mistral";
+    rev = version;
+    hash = "sha256-ddaYXvbee66Keh5loQOs4xuOrtoQ06lHlBWlLiUp2zI=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.setuptools
+    python3.pkgs.wheel
+  ];
+
+  propagatedBuildInputs = [
+    python3.pkgs.httpx
+    httpx-sse
+  ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    test = [
+      pytest
+      pytest-httpx
+    ];
+  };
+
+  meta = with lib; {
+    description = "LLM plugin providing access to Mistral models using the Mistral API";
+    homepage = "https://github.com/simonw/llm-mistral";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/packages/sse-starlette/default.nix
+++ b/packages/sse-starlette/default.nix
@@ -1,0 +1,44 @@
+{ lib
+, python3
+, fetchFromGitHub,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "sse-starlette";
+  version = "2.0.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "sysid";
+    repo = "sse-starlette";
+    rev = "v${version}";
+    hash = "sha256-kDcSG/3foP7fMZKYrkKx6FHvT9c9rSzxyv2EHjQ2WSA=";
+  };
+
+  nativeBuildInputs = [
+    python3.pkgs.pdm-backend
+  ];
+
+  propagatedBuildInputs = with python3.pkgs; [
+    anyio
+    starlette
+    uvicorn
+  ];
+
+  passthru.optional-dependencies = with python3.pkgs; {
+    examples = [
+      fastapi
+    ];
+  };
+
+  pythonImportsCheck = [ "sse_starlette" ];
+
+  meta = with lib; {
+    description = "";
+    homepage = "https://github.com/sysid/sse-starlette";
+    changelog = "https://github.com/sysid/sse-starlette/blob/${src.rev}/CHANGELOG.md";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ ];
+    mainProgram = "sse-starlette";
+  };
+}


### PR DESCRIPTION
Created for blog post.
Nix-managed `llm` with `llm-mistral` plugin added

```sh
❯ llm models
OpenAI Chat: gpt-3.5-turbo (aliases: 3.5, chatgpt)
OpenAI Chat: gpt-3.5-turbo-16k (aliases: chatgpt-16k, 3.5-16k)
OpenAI Chat: gpt-4 (aliases: 4, gpt4)
OpenAI Chat: gpt-4-32k (aliases: 4-32k)
OpenAI Chat: gpt-4-1106-preview
OpenAI Chat: gpt-4-0125-preview
OpenAI Chat: gpt-4-turbo-preview (aliases: gpt-4-turbo, 4-turbo, 4t)
OpenAI Completion: gpt-3.5-turbo-instruct (aliases: 3.5-instruct, chatgpt-instruct)
Mistral: mistral/open-mistral-7b
Mistral: mistral/mistral-tiny-2312
Mistral: mistral/mistral-tiny (aliases: mistral-tiny)
Mistral: mistral/open-mixtral-8x7b
Mistral: mistral/mistral-small-2312
Mistral: mistral/mistral-small (aliases: mistral-small)
Mistral: mistral/mistral-small-2402
Mistral: mistral/mistral-small-latest
Mistral: mistral/mistral-medium-latest
Mistral: mistral/mistral-medium-2312
Mistral: mistral/mistral-medium (aliases: mistral-medium)
Mistral: mistral/mistral-large-latest (aliases: mistral-large)
Mistral: mistral/mistral-large-2402
```